### PR TITLE
Adjust screen transition effects

### DIFF
--- a/src/components/navigation/PageTransition.tsx
+++ b/src/components/navigation/PageTransition.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useApp } from '../../contexts/AppContext';
 
 interface PageTransitionProps {
@@ -10,35 +10,49 @@ export function PageTransition({ children, transitionKey }: PageTransitionProps)
   const [isVisible, setIsVisible] = useState(false);
   const [currentKey, setCurrentKey] = useState(transitionKey);
   const [isAnimating, setIsAnimating] = useState(false);
+  
+  // Only animate transitions on Home screen
+  const shouldAnimate = useMemo(() => {
+    // transitionKey is built from `${screen}-${params}` in ScreenRenderer
+    // Keep animation for Home; disable for all other screens
+    return transitionKey.startsWith('Home-') || transitionKey === 'Home-undefined' || transitionKey === 'Home-null' || transitionKey === 'Home-{}';
+  }, [transitionKey]);
 
   useEffect(() => {
     if (transitionKey !== currentKey) {
-      setIsAnimating(true);
-      setIsVisible(false);
-      
-      setTimeout(() => {
+      if (shouldAnimate) {
+        setIsAnimating(true);
+        setIsVisible(false);
+        
+        setTimeout(() => {
+          setCurrentKey(transitionKey);
+          setIsVisible(true);
+          setTimeout(() => setIsAnimating(false), 300);
+        }, 150);
+      } else {
+        // No animation: swap immediately
+        setIsAnimating(false);
         setCurrentKey(transitionKey);
         setIsVisible(true);
-        setTimeout(() => setIsAnimating(false), 300);
-      }, 150);
+      }
     } else {
       setIsVisible(true);
     }
-  }, [transitionKey, currentKey]);
+  }, [transitionKey, currentKey, shouldAnimate]);
 
   return (
     <div className="relative overflow-hidden">
       {/* Keçid animasiyası üçün arxa fon */}
-      {isAnimating && (
+      {isAnimating && shouldAnimate && (
         <div className="absolute inset-0 bg-gradient-to-r from-emerald-500 to-green-500 opacity-10 animate-pulse z-10" />
       )}
       
       {/* Əsas məzmun */}
       <div
-        className={`transition-all duration-300 ease-out transform ${
+        className={`${shouldAnimate ? 'transition-all duration-300 ease-out transform' : ''} ${
           isVisible 
             ? 'translate-x-0 opacity-100 scale-100' 
-            : 'translate-x-4 opacity-0 scale-95'
+            : shouldAnimate ? 'translate-x-4 opacity-0 scale-95' : ''
         }`}
       >
         {children}


### PR DESCRIPTION
Disable page transition effects on all screens except the Home screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-14bb6a23-d5d4-4808-98a3-5babf3171f1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14bb6a23-d5d4-4808-98a3-5babf3171f1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

