### PR TITLE
Exam simulator continue button page styling

### DIFF
--- a/src/components/navigation/ScreenRenderer.tsx
+++ b/src/components/navigation/ScreenRenderer.tsx
@@ -17,6 +17,7 @@ import { PackagesScreen } from '../screens/PackagesScreen';
 import { AIChatScreen } from '../screens/AIChatScreen';
 import { TransactionsScreen } from '../screens/TransactionsScreen';
 import { SettingsScreen } from '../screens/SettingsScreen';
+import { ExamIntroScreen } from '../screens/ExamIntroScreen';
 
 export function ScreenRenderer() {
   const { currentScreen, currentTab } = useApp();
@@ -46,6 +47,7 @@ export function ScreenRenderer() {
       {currentScreen.screen === 'Practice' && <PracticeScreen />}
       {currentScreen.screen === 'Exam' && <ExamScreen />}
       {currentScreen.screen === 'ExamConfig' && <ExamConfigScreen />}
+      {currentScreen.screen === 'ExamIntro' && <ExamIntroScreen />}
       {currentScreen.screen === 'ExamRun' && <ExamRunScreen />}
       {currentScreen.screen === 'Results' && <ResultsScreen />}
       {currentScreen.screen === 'Mistakes' && <MistakesScreen />}
@@ -55,7 +57,7 @@ export function ScreenRenderer() {
       {currentScreen.screen === 'Settings' && <SettingsScreen />}
       
       {/* Default */}
-      {!['Home', 'Topics', 'Store', 'More', 'Lesson', 'Practice', 'Exam', 'ExamConfig', 'ExamRun', 'Results', 'Mistakes', 'TeacherContact', 'Packages', 'Transactions', 'Settings'].includes(currentScreen.screen) && <HomeScreen />}
+      {!['Home', 'Topics', 'Store', 'More', 'Lesson', 'Practice', 'Exam', 'ExamConfig', 'ExamIntro', 'ExamRun', 'Results', 'Mistakes', 'TeacherContact', 'Packages', 'Transactions', 'Settings'].includes(currentScreen.screen) && <HomeScreen />}
     </PageTransition>
   );
 }

--- a/src/components/screens/ExamConfigScreen.tsx
+++ b/src/components/screens/ExamConfigScreen.tsx
@@ -94,7 +94,7 @@ export function ExamConfigScreen() {
                 )}
               </div>
 
-              <Button onClick={start} className="w-full">
+              <Button onClick={() => navigate('ExamIntro')} className="w-full">
                 Davam et
               </Button>
             </div>

--- a/src/components/screens/ExamIntroScreen.tsx
+++ b/src/components/screens/ExamIntroScreen.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useApp } from '../../contexts/AppContext';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+
+export function ExamIntroScreen() {
+  const { isDarkMode, navigate } = useApp();
+
+  const startExam = () => {
+    const config = { mode: 'simulator', questionsCount: 10 };
+    navigate('ExamRun', { config });
+  };
+
+  return (
+    <div className={`relative p-3 pb-24 min-h-screen transition-colors duration-200 ${
+      isDarkMode ? 'bg-gray-900' : 'bg-emerald-50'
+    }`}>
+      {/* Soft background illustration */}
+      <div className="pointer-events-none select-none absolute inset-0 opacity-10">
+        <div className="absolute -top-24 -right-24 w-[420px] h-[420px] bg-emerald-300 rounded-full blur-3xl"></div>
+        <div className="absolute -bottom-24 -left-24 w-[420px] h-[420px] bg-emerald-400 rounded-full blur-3xl"></div>
+      </div>
+
+      <div className="relative">
+        <Card className={`${isDarkMode ? 'bg-gray-800/80' : 'bg-white/90'} backdrop-blur-sm`}> 
+          <div className="text-center space-y-4">
+            <div className={`text-lg font-black ${isDarkMode ? 'text-gray-100' : 'text-gray-800'}`}>
+              Hörmətli istifadəçi!
+            </div>
+            <div className={`leading-relaxed text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+              Siz <span className="font-bold">İMTAHAN SİMULYATORU</span> vasitəsilə Yol Hərəkəti Qaydaları üzrə
+              nəzəri imtahan verəcəksiniz. Diqqətinizə 10 sualdan ibarət bilet təqdim
+              olunacaqdır. Cavablandırmaq istədiyiniz suala toxunduqdan sonra həmin sual
+              daha iri ölçüdə təsvir olunacaq. Göstərilən cavablardan düzgün hesab etdiyinizi
+              seçib sonra <span className="font-bold">“TƏSDİQ”</span> düyməsini sıxın. Digər sualı seçmək üçün
+              <span className="font-bold"> “GERİYƏ”</span> düyməsini istifadə edin.
+            </div>
+            <div className={`leading-relaxed text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+              Əgər 15 dəqiqə ərzində 10 sualdan 9 sualı düzgün cavablandırsanız, imtahanı uğurla
+              vermiş sayılacaqsınız. Yalnız bir səhv etmək şansınız var. Monitorun aşağı hissəsində
+              imtahanın gedişini bildirən vaxt və sualların nömrələri əks olunur.
+            </div>
+            <div className={`text-sm font-semibold ${isDarkMode ? 'text-gray-200' : 'text-gray-800'}`}>
+              Sizə uğurlar arzulayırıq!
+            </div>
+
+            {/* Masked ID area mimic */}
+            <div className={`mx-auto w-64 h-8 rounded-full ${isDarkMode ? 'bg-gray-700' : 'bg-emerald-100'} flex items-center justify-center text-xs text-gray-400`}>
+              ________
+            </div>
+
+            <div className="pt-2">
+              <Button onClick={startExam} className="w-full">
+                İMTAHANA BAŞLA
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add an exam introduction screen and route the 'Davam et' button to it, fulfilling the user's request for pre-exam instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-890e1ef6-caea-4df7-a0bc-949924f4bc66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-890e1ef6-caea-4df7-a0bc-949924f4bc66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

