### PR TITLE
Align faq images and adjust text spacing

### DIFF
--- a/src/components/screens/ExamRunScreen.tsx
+++ b/src/components/screens/ExamRunScreen.tsx
@@ -170,7 +170,7 @@ export function ExamRunScreen() {
                   />
                 </div>
                 <div className={`px-3 py-2 mt-2 ${answered ? 'text-white' : 'text-gray-900'} text-xs leading-tight`}>
-                  <div>{truncateText(question.text, 100)}</div>
+                  <div>{truncateText(question.text, 80)}</div>
                 </div>
               </button>
             );


### PR DESCRIPTION
Reduce question preview character limit from 100 to 80 to improve image alignment and text layout in the general questions section.

---
<a href="https://cursor.com/background-agent?bcId=bc-c69cab64-41c3-4600-adf3-2659b055f1fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c69cab64-41c3-4600-adf3-2659b055f1fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

