### PR TITLE
Update exam simulator and lesson schedule display

### DIFF
--- a/src/components/navigation/ScreenRenderer.tsx
+++ b/src/components/navigation/ScreenRenderer.tsx
@@ -19,6 +19,7 @@ import { TransactionsScreen } from '../screens/TransactionsScreen';
 import { SettingsScreen } from '../screens/SettingsScreen';
 import { ExamIntroScreen } from '../screens/ExamIntroScreen';
 import { ActivationScheduledScreen } from '../screens/ActivationScheduledScreen';
+import { OnlineLessonsScreen } from '../screens/OnlineLessonsScreen';
 
 export function ScreenRenderer() {
   const { currentScreen, currentTab } = useApp();
@@ -46,6 +47,7 @@ export function ScreenRenderer() {
       {/* Stack screens */}
       {currentScreen.screen === 'Lesson' && <LessonScreen />}
       {currentScreen.screen === 'Practice' && <PracticeScreen />}
+      {currentScreen.screen === 'OnlineLessons' && <OnlineLessonsScreen />}
       {currentScreen.screen === 'Exam' && <ExamScreen />}
       {currentScreen.screen === 'ExamConfig' && <ExamConfigScreen />}
       {currentScreen.screen === 'ExamIntro' && <ExamIntroScreen />}
@@ -59,7 +61,7 @@ export function ScreenRenderer() {
       {currentScreen.screen === 'Settings' && <SettingsScreen />}
       
       {/* Default */}
-      {!['Home', 'Topics', 'Store', 'More', 'Lesson', 'Practice', 'Exam', 'ExamConfig', 'ExamIntro', 'ExamRun', 'Results', 'Mistakes', 'TeacherContact', 'Packages', 'ActivationScheduled', 'Transactions', 'Settings'].includes(currentScreen.screen) && <HomeScreen />}
+      {!['Home', 'Topics', 'Store', 'More', 'Lesson', 'Practice', 'OnlineLessons', 'Exam', 'ExamConfig', 'ExamIntro', 'ExamRun', 'Results', 'Mistakes', 'TeacherContact', 'Packages', 'ActivationScheduled', 'Transactions', 'Settings'].includes(currentScreen.screen) && <HomeScreen />}
     </PageTransition>
   );
 }

--- a/src/components/screens/HomeScreen.tsx
+++ b/src/components/screens/HomeScreen.tsx
@@ -11,7 +11,7 @@ export function HomeScreen() {
   
   const gridItems = [
     { key: 'video', label: t.videoLessons, action: () => navigate('Lesson', { moduleId: 'M8' }), emoji: '🎬' },
-    { key: 'examSimulator', label: t.examSimulator, action: () => navigate('ExamConfig', { mode: 'simulator' }), emoji: '🧪' },
+    { key: 'onlineLesson', label: t.onlineLesson, action: () => navigate('OnlineLessons'), emoji: '🌐' },
     { key: 'quick', label: t.quickTest, action: () => navigate('Practice'), emoji: '📝' },
     { key: 'tests', label: t.tests, action: () => navigate('Practice'), emoji: '📄' },
     { key: 'fines', label: t.fines, action: () => alert('Cərimələr (demo)'), emoji: '💸' },

--- a/src/components/screens/OnlineLessonsScreen.tsx
+++ b/src/components/screens/OnlineLessonsScreen.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo } from 'react';
+import { useApp } from '../../contexts/AppContext';
+
+type LessonItem = {
+  id: string;
+  title: string;
+  instructor: string;
+  date: string; // ISO string
+  durationMin: number;
+};
+
+export function OnlineLessonsScreen() {
+  const { t, isDarkMode, goBack } = useApp();
+
+  // Mock data source (can be replaced with real API later)
+  const lessons: LessonItem[] = useMemo(() => [
+    { id: 'l1', title: 'M8: Yol nişanları — Canlı dərs', instructor: 'Ə.Talıbov', date: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(), durationMin: 60 },
+    { id: 'l2', title: 'M9: Üstünlük qaydaları — Canlı dərs', instructor: 'R.Məmmədov', date: new Date(Date.now() + 26 * 60 * 60 * 1000).toISOString(), durationMin: 75 },
+    { id: 'l3', title: 'M10: Sürət məhdudiyyətləri', instructor: 'Ə.Talıbov', date: new Date(Date.now() + 50 * 60 * 60 * 1000).toISOString(), durationMin: 50 },
+    { id: 'l4', title: 'M11: Parklanma qaydaları', instructor: 'N.Quliyev', date: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(), durationMin: 55 },
+  ], []);
+
+  const upcoming = useMemo(() => {
+    const now = new Date();
+    return lessons
+      .filter(l => new Date(l.date) > now)
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+      .slice(0, 2);
+  }, [lessons]);
+
+  const groupedByDay = useMemo(() => {
+    const map = new Map<string, LessonItem[]>();
+    for (const l of lessons.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())) {
+      const d = new Date(l.date);
+      const key = d.toLocaleDateString('az-AZ', { weekday: 'long', day: '2-digit', month: 'long' });
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(l);
+    }
+    return Array.from(map.entries());
+  }, [lessons]);
+
+  return (
+    <div className={`p-3 pb-6 min-h-screen transition-colors duration-200 ${
+      isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
+    }`}>
+      <div className="-mx-3 -mt-2 mb-3 px-3 py-2 flex items-center gap-2">
+        <button
+          onClick={goBack}
+          className={`px-2 py-1 rounded text-xs font-semibold ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-white text-gray-700 border border-gray-200'}`}
+        >
+          ← {t.home}
+        </button>
+        <div className={`text-sm font-extrabold ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{t.onlineLesson}</div>
+      </div>
+
+      {/* Upcoming (top 2) */}
+      <div className="space-y-2">
+        <div className={`${isDarkMode ? 'text-gray-300' : 'text-gray-600'} text-xs font-semibold`}>{t.upcomingLessons}</div>
+        {upcoming.map((l, idx) => {
+          const d = new Date(l.date);
+          return (
+            <div
+              key={l.id}
+              className={`rounded-2xl border p-4 flex items-start gap-3 ${
+                isDarkMode ? 'bg-emerald-900/10 border-emerald-800' : 'bg-emerald-50 border-emerald-200'
+              }`}
+            >
+              <div className={`w-12 h-12 rounded-xl flex items-center justify-center text-xl ${
+                isDarkMode ? 'bg-emerald-800 text-emerald-200' : 'bg-white text-emerald-700 border border-emerald-200'
+              }`}>📡</div>
+              <div className="flex-1">
+                <div className={`text-sm font-black leading-tight ${isDarkMode ? 'text-emerald-100' : 'text-emerald-900'}`}>{l.title}</div>
+                <div className={`text-xs mt-1 ${isDarkMode ? 'text-emerald-200' : 'text-emerald-700'}`}>
+                  {d.toLocaleString('az-AZ', { weekday: 'long', hour: '2-digit', minute: '2-digit', day: '2-digit', month: 'short' })}
+                  {' • '}{l.instructor}{' • '}{l.durationMin} dəq
+                </div>
+              </div>
+              <button
+                className={`px-3 py-2 rounded-lg text-xs font-bold whitespace-nowrap ${
+                  isDarkMode ? 'bg-emerald-700 text-emerald-100 hover:bg-emerald-600' : 'bg-emerald-600 text-white hover:bg-emerald-700'
+                }`}
+                onClick={() => alert('Dərs qoşulma linki (demo)')}
+              >
+                Canlı qoşul
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Schedule */}
+      <div className="mt-4">
+        <div className={`text-xs font-semibold mb-2 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>{t.classSchedule}</div>
+        <div className="space-y-3">
+          {groupedByDay.map(([dayLabel, items]) => (
+            <div key={dayLabel} className="space-y-2">
+              <div className={`sticky top-0 z-10 -mx-3 px-3 py-1 text-[11px] font-bold tracking-wide ${
+                isDarkMode ? 'bg-gray-900 text-gray-400' : 'bg-gray-50 text-gray-500'
+              }`}>{dayLabel}</div>
+              {items.map((l) => {
+                const d = new Date(l.date);
+                return (
+                  <div
+                    key={l.id}
+                    className={`rounded-xl border p-3 flex items-center gap-3 ${
+                      isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+                    }`}
+                  >
+                    <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-base ${
+                      isDarkMode ? 'bg-gray-700 text-gray-200' : 'bg-gray-50 text-gray-700'
+                    }`}>🎓</div>
+                    <div className="flex-1 min-w-0">
+                      <div className={`text-sm font-bold truncate ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{l.title}</div>
+                      <div className={`text-xs ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                        {d.toLocaleTimeString('az-AZ', { hour: '2-digit', minute: '2-digit' })} • {l.instructor} • {l.durationMin} dəq
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => alert('Yadda saxlandı (demo)')}
+                      className={`px-2 py-1 rounded text-[11px] font-semibold ${
+                        isDarkMode ? 'bg-gray-700 text-gray-200 hover:bg-gray-600' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      }`}
+                    >
+                      + Təqvim
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -14,6 +14,7 @@ export const dictionaries = {
     // Actions
     quickTest: 'Sürətli test',
     videoLessons: '3D video dərs',
+    onlineLesson: 'Onlayn dərs',
     continue: 'Haradan davam edim?',
     startLesson: 'Dərsə başla',
     startTest: 'Testə başla',
@@ -67,6 +68,8 @@ export const dictionaries = {
     notifications: 'Bildirişlər',
     assistant: 'AI köməkçi',
     language: 'Dil',
+    upcomingLessons: 'Ən son keçiriləcək dərslər',
+    classSchedule: 'Dərs cədvəli',
   },
   
   ru: {
@@ -82,6 +85,7 @@ export const dictionaries = {
     // Actions
     quickTest: 'Быстрый тест',
     videoLessons: '3D видео урок',
+    onlineLesson: 'Онлайн урок',
     continue: 'Где продолжить?',
     startLesson: 'Начать урок',
     startTest: 'Начать тест',
@@ -135,5 +139,7 @@ export const dictionaries = {
     notifications: 'Уведомления',
     assistant: 'AI помощник',
     language: 'Язык',
+    upcomingLessons: 'Ближайшие занятия',
+    classSchedule: 'Расписание занятий',
   },
 };


### PR DESCRIPTION
Replace the 'Exam Simulator' button with 'Online Lessons' and add a new screen displaying upcoming lessons and a class schedule.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3ef45ff-f9a5-4eef-84d2-17128d897e10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3ef45ff-f9a5-4eef-84d2-17128d897e10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

