### PR TITLE
Display traffic rules with categories and details

### DIFF
--- a/src/components/screens/MoreScreen.tsx
+++ b/src/components/screens/MoreScreen.tsx
@@ -5,6 +5,7 @@ export function MoreScreen() {
   const { navigate, balance, tickets, activePackage, hasActivePackage, isDarkMode } = useApp();
   
   const moreItems = [
+    { key: 'rules', label: 'Qaydalar', emoji: '📘', action: () => navigate('Rules') },
     { key: 'packages', label: 'Təlim paketləri', emoji: '📦', action: () => navigate('Packages') },
     { key: 'balance', label: 'Daxili balans', emoji: '💰', action: () => navigate('Transactions') },
     { key: 'certificate', label: 'Şəhadətnamə almaq', emoji: '🏆', action: () => alert('Şəhadətnamə almaq (demo)') },

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -134,8 +134,8 @@ export function RulesScreen() {
       isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
     }`}>
       {/* Search / Filter */}
-      <div className="mb-3 sticky top-[44px] z-30">
-        <div className="flex items-center gap-2">
+      <div className={`mb-3 sticky top-0 z-30 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
+        <div className="flex items-center gap-2 py-1">
           <button onClick={handleBackClick} className={`px-3 py-2 rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700'}`}>←</button>
           <div className={`flex items-center gap-2 flex-1 px-3 py-2 rounded-xl border ${
             isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -204,6 +204,9 @@ export function RulesScreen() {
             <div>
               {signsStage === 'categories' ? (
                 <div className="space-y-2">
+                  <div className="mb-2">
+                    <button onClick={() => setView('home')} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+                  </div>
                   {SIGN_CATEGORIES.map(cat => (
                     <button
                       key={cat.key}
@@ -218,7 +221,7 @@ export function RulesScreen() {
               ) : (
                 <>
                   <div className="mb-2">
-                    <button onClick={() => { setSignsStage('categories'); setSelectedSignId(null); }} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← 3 seçimə qayıt</button>
+                    <button onClick={() => { setSignsStage('categories'); setSelectedSignId(null); }} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     {filteredSigns.map((s, idx) => (
@@ -241,6 +244,9 @@ export function RulesScreen() {
 
                   {selectedSign && (
                     <Card className="mt-2">
+                      <div className="mb-2">
+                        <button onClick={() => setSelectedSignId(null)} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+                      </div>
                       <div className="flex items-center gap-3">
                         <div className="w-16 h-16 rounded-lg overflow-hidden flex items-center justify-center bg-gray-50">
                           <img src={selectedSign.img} alt={selectedSign.name} className="w-14 h-14 object-contain" onError={handleImgError} />

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -44,20 +44,34 @@ const VERTICAL_SIGNS = [
   { id: 'vs2', name: 'Maneə əks etdiricisi', description: 'Maneələrin kənarlarını göstərir.' },
 ];
 
-// AZ traffic rules topics (titles + brief summaries)
+// AZ traffic rules topics (titles + brief summaries) – 26 items
 const AZ_RULES = [
-  { id: 'r1', title: 'Maddə 1. Əsas anlayışlar', content: 'Qanunda işlədilən termin və anlayışların izahı verilir. Nəqliyyat vasitəsi, sürücü, sərnişin, piyada, yol, yol hərəkəti iştirakçısı kimi anlayışlar dəqiq müəyyənləşdirilir. Bu anlayışlar bütün digər maddələrin düzgün başa düşülməsi üçün bazadır.' },
-  { id: 'r2', title: 'Maddə 2. Qanunun təyinatı', content: 'Qanunun məqsədi yol hərəkətində təhlükəsizliyi təmin etmək və hərəkətin təşkili üçün hüquqi çərçivə yaratmaqdır. Həm sürücülər, həm də digər iştirakçılar üçün ümumi davranış qaydaları müəyyən edilir.' },
-  { id: 'r3', title: 'Maddə 3. Yol hərəkəti haqqında qanunvericilik', content: 'Yol hərəkətini tənzimləyən normativ aktların sistemi göstərilir. Qanunun digər qaydalar və standartlarla əlaqəsi və üstünlük münasibətləri izah olunur.' },
-  { id: 'r4', title: 'Maddə 4. Dövlət orqanlarının vəzifələri', content: 'Yol hərəkəti sahəsində nəzarət, təşkil və təhlükəsizliyin təmin edilməsi üzrə dövlət qurumlarının səlahiyyətləri təsbit olunur. Təlim, maarifləndirmə və infrastrukturun saxlanması da bu vəzifələrə daxildir.' },
-  { id: 'r5', title: 'Maddə 5. Hüquqi şəxslərin vəzifələri', content: 'Daşıma fəaliyyəti göstərən və ya nəqliyyat parkı olan təşkilatların öhdəlikləri müəyyən edilir. Texniki sazlıq, sürücülərin hazırlığı və təhlükəsizlik tələblərinə əməl olunması şərtdir.' },
-  { id: 'r6', title: 'Maddə 6. Fiziki şəxslərin hüquq və vəzifələri', content: 'Sürücü və piyadaların hüquqları, vəzifələri və məsuliyyəti göstərilir. Hərəkət zamanı bir-birinə hörmət və təhlükəsizliyin təmin edilməsi əsas prinsipdir.' },
-  { id: 'r7', title: 'Maddə 6-1. Beynəlxalq daşımalarda iştirak edənlərin vəzifələri', content: 'Beynəlxalq sərnişin və yük daşımalarını təşkil edən və icra edən şəxslərə əlavə tələblər müəyyən olunur. Sənədləşmə, təhlükəsizlik və beynəlxalq normalara uyğunluq önəmlidir.' },
-  { id: 'r8', title: 'Maddə 7. Yol hərəkətinin təşkili', content: 'Yol hərəkatının planlaşdırılması, nişan və nişanlanmaların tətbiqi qaydaları izah edilir. Hərəkət axınının təhlükəsiz və fasiləsiz olması üçün təşkilati tədbirlər nəzərdə tutulur.' },
-  { id: 'r9', title: 'Maddə 8. Hərəkətə başlama və manevr', content: 'Hərəkətə başlama, dönmə, ötmə, zolaq dəyişmə və digər manevrlərin qaydaları təsvir olunur. Sürücü əvvəlcədən siqnal verməli və təhlükəsizliyi təmin etməlidir.' },
-  { id: 'r10', title: 'Maddə 9. Dayanma və durma', content: 'Dayanma və durmanın icazəli və qadağan edildiyi hallar göstərilir. Qaydaların pozulması yol hərəkətinə maneə yarada və təhlükə doğura bilər.' },
-  { id: 'r11', title: 'Maddə 10. Sürət rejimi', content: 'Müxtəlif yol şəraitlərində tətbiq olunan sürət məhdudiyyətləri müəyyən edilir. Zərurət yarandıqda sürət hava, yol və nəqliyyat axınına uyğun azaldılmalıdır.' },
-  { id: 'r12', title: 'Maddə 11. Piyadaların hərəkəti', content: 'Piyadaların keçidlərdən istifadə qaydaları, yolun təhlükəsiz keçilməsi və gecə-gündüz görünmə tələbləri izah olunur. Sürücülər piyadalara xüsusi diqqət yetirməlidirlər.' },
+  { id: 'r1', title: 'Maddə 1. Əsas anlayışlar', content: 'Qanunda istifadə olunan terminlər izah edilir. “Yol”, “sürücü”, “piyada”, “nəqliyyat vasitəsi” kimi anlayışlar dəqiq tərif olunur. Bu terminlər digər maddələrin düzgün anlaşılması üçün baza yaradır.' },
+  { id: 'r2', title: 'Maddə 2. Qanunun təyinatı', content: 'Yol hərəkəti sahəsində təhlükəsizlik və nizam-intizamı təmin etmək məqsədi açıqlanır. Qanun, bütün iştirakçılar üçün hüquqi çərçivə və davranış standartları müəyyənləşdirir.' },
+  { id: 'r3', title: 'Maddə 3. Yol hərəkəti haqqında qanunvericilik', content: 'Tətbiq olunan normativ sənədlərin iyerarxiyası göstərilir. Standartlar, qaydalar və digər aktlarla qarşılıqlı əlaqə və üstünlük prinsipləri müəyyən edilir.' },
+  { id: 'r4', title: 'Maddə 4. Dövlət orqanlarının vəzifələri', content: 'Yol hərəkətinə nəzarət, təşkil və təhlükəsizlik üzrə səlahiyyətlər sadalanır. Maarifləndirmə, statistika aparılması və infrastrukturun saxlanılması da bu səlahiyyətlərə daxildir.' },
+  { id: 'r5', title: 'Maddə 5. Hüquqi şəxslərin vəzifələri', content: 'Daşımalarla məşğul olan və ya avtomobil parkı saxlayan təşkilatların öhdəlikləri müəyyən edilir. Texniki baxım, sürücülərin hazırlığı və təhlükəsizlik standartlarına əməl vacibdir.' },
+  { id: 'r6', title: 'Maddə 6. Fiziki şəxslərin hüquq və vəzifələri', content: 'Sürücü, sərnişin və piyadaların hüquqları və öhdəlikləri açıqlanır. Hörmət, ehtiyat və təhlükəsizliyin prioritetliyi vurğulanır.' },
+  { id: 'r7', title: 'Maddə 6-1. Beynəlxalq daşımalarda vəzifələr', content: 'Beynəlxalq sərnişin və yük daşımalarını təşkil edən və icra edənlər üçün əlavə tələblər göstərilir. Sənədləşmə, marşrut planlaşdırılması və təhlükəsizlik normaları əsasdır.' },
+  { id: 'r8', title: 'Maddə 7. Yol hərəkətinin təşkili', content: 'Nişanların, işıqforların və nişanlanma xətlərinin tətbiqi qaydaları izah edilir. Hərəkət axınının fasiləsizliyi və təhlükəsizliyi üçün təşkilati tədbirlər göstərilir.' },
+  { id: 'r9', title: 'Maddə 8. Başlanğıc və manevrlər', content: 'Hərəkətə başlama, dönmə, ötmə və zolaq dəyişmə zamanı davranış qaydaları verilir. Sürücü əvvəlcədən siqnal verir və təhlükəsizliyi təmin edir.' },
+  { id: 'r10', title: 'Maddə 9. Dayanma və durma', content: 'Dayanma/durma yerləri və qadağaları sadalanır. Görünüşə mane olmamaq və hərəkətə təhlükə yaratmamaq əsas şərtdir.' },
+  { id: 'r11', title: 'Maddə 10. Sürət rejimi', content: 'Müxtəlif yol şəraitləri üçün sürət məhdudiyyətləri müəyyən edilir. Havanın, yolun və nəqliyyat axınının vəziyyətinə uyğun sürət seçilməlidir.' },
+  { id: 'r12', title: 'Maddə 11. Piyadaların hərəkəti', content: 'Piyadaların keçidlərdən istifadəsi və yolun təhlükəsiz keçilməsi qaydaları verilir. Sürücülərin piyadalara qarşı məsuliyyəti ayrıca vurğulanır.' },
+  { id: 'r13', title: 'Maddə 12. Sərnişinlərin daşınması', content: 'Avtomobildə sərnişinlərin oturması, uşaq oturacaqları və təhlükəsizlik kəmərləri ilə bağlı tələblər. Sərnişinlərin düşmə/minmə zamanı təhlükəsizlik qaydaları göstərilir.' },
+  { id: 'r14', title: 'Maddə 13. Yük daşınması', content: 'Yükün yerləşdirilməsi, bərkidilməsi və ölçü-kütlə məhdudiyyətləri izah olunur. Yük hərəkətə, görünüşə və stabilliyə mane olmamalıdır.' },
+  { id: 'r15', title: 'Maddə 14. Xüsusi siqnalların tətbiqi', content: 'Xüsusi təyinatlı nəqliyyat vasitələrinin işıq və səs siqnallarından istifadəsi qaydaları. Digər sürücülərin belə vasitələrə üstünlük vermə öhdəliyi xatırladılır.' },
+  { id: 'r16', title: 'Maddə 15. Dəmiryolu keçidləri', content: 'Keçidlərdən istifadə zamanı dayanma, görünüş və siqnalların tələbləri təsvir edilir. Qırmızı işıq və ya baryerlər zamanı keçid qadağandır.' },
+  { id: 'r17', title: 'Maddə 16. Avtobus zolaqları və ictimai nəqliyyat', content: 'İctimai nəqliyyat üçün ayrılmış zolaqlardan istifadə qaydaları. Sürücülər bu zolaqlara məhdud hallarda daxil ola bilər.' },
+  { id: 'r18', title: 'Maddə 17. Yol nişanları və nişanlanma', content: 'Yol nişanlarının və üfüqi/vertikal nişanlanmanın hüquqi qüvvəsi və üstünlüyü göstərilir. Ziddiyyət olduqda prioritet qaydası açıqlanır.' },
+  { id: 'r19', title: 'Maddə 18. İşıqfor və tənzimləyici siqnalları', content: 'İşıqfor işıqlarının mənası və tənzimləyicinin jestlərinə tabe olmaq qaydaları izah olunur. Ziddiyyət olduqda tənzimləyici üstünlük təşkil edir.' },
+  { id: 'r20', title: 'Maddə 19. Ötmə və qarşıdan gələn hərəkət', content: 'Ötmənin icazəli olduğu hallar, qadağalar və təhlükəsizlik şərtləri. Qarşıdan gələn nəqliyyatla qarşılaşmada davranış qaydaları qeyd edilir.' },
+  { id: 'r21', title: 'Maddə 20. Fövqəladə dayanma və nişanlar', content: 'Qəza dayanacağı və fövqəladə işıq siqnalının tətbiqi qaydaları. Maneə barədə digər sürücülərin vaxtında xəbərdar edilməsi vacibdir.' },
+  { id: 'r22', title: 'Maddə 21. Sərxoşluq və tibbi yoxlama', content: 'Spirtli içki və ya narkotik təsiri altında idarənin qadağan edilməsi. Tibbi müayinəyə göndərmə və hüquqi nəticələr izah olunur.' },
+  { id: 'r23', title: 'Maddə 22. Velosiped və fərdi mikromobilite', content: 'Velosiped, skuter kimi vasitələrin hərəkət qaydaları və prioritetləri. Yolun kənarı və velosiped zolaqlarından istifadə tələbləri verilir.' },
+  { id: 'r24', title: 'Maddə 23. Ekoloji tələblər', content: 'Zərərli tullantıların azaldılması, səs-küy və tüstü normativləri. Texniki baxımın vaxtında aparılması ekoloji təhlükəsizlik üçün vacibdir.' },
+  { id: 'r25', title: 'Maddə 24. Qəzalar və hadisələrin rəsmiləşdirilməsi', content: 'Yol-nəqliyyat hadisəsi zamanı tərəflərin davranışı, ilkin yardım və polisin çağırılması qaydaları. Foto/video sənədləşdirmə və protokollaşdırma prinsipləri qeyd olunur.' },
+  { id: 'r26', title: 'Maddə 25. Məsuliyyət və cərimələr', content: 'Qaydaların pozulmasına görə inzibati məsuliyyətin əsasları və sanksiyalar xatırladılır. Təhlükəsizliyin təmin olunması üçün profilaktik tədbirlər tövsiyə edilir.' },
 ];
 
 export function RulesScreen() {
@@ -120,7 +134,7 @@ export function RulesScreen() {
       isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
     }`}>
       {/* Search / Filter */}
-      <div className="mb-3">
+      <div className="mb-3 sticky top-[44px] z-30">
         <div className="flex items-center gap-2">
           <button onClick={handleBackClick} className={`px-3 py-2 rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700'}`}>←</button>
           <div className={`flex items-center gap-2 flex-1 px-3 py-2 rounded-xl border ${
@@ -206,6 +220,9 @@ export function RulesScreen() {
                 </div>
               ) : (
                 <>
+                  <div className="mb-2">
+                    <button onClick={() => { setSignsStage('categories'); setSelectedSignId(null); }} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+                  </div>
                   <div className="grid grid-cols-2 gap-2">
                     {filteredSigns.map((s, idx) => (
                       <SlideTransition key={s.id} direction="right" delay={200 + idx * 50}>

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -265,6 +265,9 @@ export function RulesScreen() {
 
           {view === 'markings' && (
             <div>
+              <div className="mb-2">
+                <button onClick={() => setView('home')} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+              </div>
               <div className="grid grid-cols-2 gap-2">
                 {filteredMarkings.map(m => (
                   <Card key={m.id} className="p-3">
@@ -278,6 +281,9 @@ export function RulesScreen() {
 
           {view === 'vertical' && (
             <div>
+              <div className="mb-2">
+                <button onClick={() => setView('home')} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+              </div>
               <div className="grid grid-cols-2 gap-2">
                 {filteredVertical.map(v => (
                   <Card key={v.id} className="p-3">

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -61,7 +61,7 @@ const AZ_RULES = [
 ];
 
 export function RulesScreen() {
-  const { isDarkMode } = useApp();
+  const { isDarkMode, goBack } = useApp();
   // Home with 3 entries; each opens its own sub-view
   const [view, setView] = useState<'home' | 'signs' | 'markings' | 'vertical'>('home');
   const [activeSignCategory, setActiveSignCategory] = useState<SignCategoryKey>('prohibitory');
@@ -100,29 +100,47 @@ export function RulesScreen() {
     target.src = '/image.png';
   };
 
+  const handleBackClick = () => {
+    if (view === 'signs' && signsStage === 'detail') {
+      setSignsStage('categories');
+      setSelectedSignId(null);
+      return;
+    }
+    if (view !== 'home') {
+      setView('home');
+      return;
+    }
+    if (goBack) {
+      try { goBack(); } catch (_) { /* noop */ }
+    }
+  };
+
   return (
     <div className={`p-3 pb-24 min-h-screen transition-colors duration-200 ${
       isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
     }`}>
       {/* Search / Filter */}
       <div className="mb-3">
-        <div className={`flex items-center gap-2 px-3 py-2 rounded-xl border ${
-          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
-        }`}>
-          <span className={`${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>🔎</span>
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Axtarış..."
-            className={`flex-1 bg-transparent outline-none text-sm ${isDarkMode ? 'text-gray-100 placeholder-gray-500' : 'text-gray-900 placeholder-gray-500'}`}
-          />
-          {query && (
-            <button
-              aria-label="Təmizlə"
-              onClick={() => setQuery('')}
-              className={`${isDarkMode ? 'text-gray-400 hover:text-gray-200' : 'text-gray-500 hover:text-gray-700'}`}
-            >✕</button>
-          )}
+        <div className="flex items-center gap-2">
+          <button onClick={handleBackClick} className={`px-3 py-2 rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700'}`}>←</button>
+          <div className={`flex items-center gap-2 flex-1 px-3 py-2 rounded-xl border ${
+            isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
+          }`}>
+            <span className={`${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>🔎</span>
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Axtarış..."
+              className={`flex-1 bg-transparent outline-none text-sm ${isDarkMode ? 'text-gray-100 placeholder-gray-500' : 'text-gray-900 placeholder-gray-500'}`}
+            />
+            {query && (
+              <button
+                aria-label="Təmizlə"
+                onClick={() => setQuery('')}
+                className={`${isDarkMode ? 'text-gray-400 hover:text-gray-200' : 'text-gray-500 hover:text-gray-700'}`}
+              >✕</button>
+            )}
+          </div>
         </div>
       </div>
 
@@ -163,14 +181,12 @@ export function RulesScreen() {
         </Card>
       ) : (
         <Card className="mb-3">
-          <div className="flex items-center justify-between mb-2">
-            <button onClick={() => { if (view === 'signs' && signsStage === 'detail') { setSignsStage('categories'); setSelectedSignId(null); } else { setView('home'); } }} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+          <div className="mb-2">
             <div className={`text-xs uppercase tracking-wide font-bold ${isDarkMode ? 'text-gray-300' : 'text-gray-500'}`}>
               {view === 'signs' && (signsStage === 'categories' ? 'Nişanlar' : (SIGN_CATEGORIES.find(c => c.key === selectedCategory)?.title || 'Nişanlar'))}
               {view === 'markings' && 'Nişanlanma xəttləri'}
               {view === 'vertical' && 'Vertikal nişanlar'}
             </div>
-            <div className="opacity-0">←</div>
           </div>
 
           {view === 'signs' && (

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -53,8 +53,8 @@ const AZ_RULES = [
 
 export function RulesScreen() {
   const { isDarkMode } = useApp();
-  // Only three sections as requested; rules list will be shown below them
-  const [activeSection, setActiveSection] = useState<'signs' | 'markings' | 'vertical'>('signs');
+  // Home with 3 entries; each opens its own sub-view
+  const [view, setView] = useState<'home' | 'signs' | 'markings' | 'vertical'>('home');
   const [activeSignCategory, setActiveSignCategory] = useState<SignCategoryKey>('prohibitory');
   const [selectedSignId, setSelectedSignId] = useState<string | null>(null);
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
@@ -115,98 +115,129 @@ export function RulesScreen() {
         </div>
       </div>
 
-      <Card className="mb-3">
-        <div className="flex items-center justify-between mb-2">
-          <div className={`text-xs uppercase tracking-wide font-bold ${isDarkMode ? 'text-gray-300' : 'text-gray-500'}`}>Nişanlar</div>
-          <div className={`h-px flex-1 ml-2 ${isDarkMode ? 'bg-gray-700' : 'bg-gray-200'}`} />
-        </div>
-
-        {/* Sections */}
-        <div className="flex gap-2 mb-3">
-          <button onClick={() => setActiveSection('signs')} className={`px-3 py-1 rounded-lg text-xs font-bold ${activeSection==='signs' ? 'bg-emerald-600 text-white' : (isDarkMode ? 'bg-gray-700 text-gray-200' : 'bg-gray-100 text-gray-700')}`}>Nişanlar</button>
-          <button onClick={() => setActiveSection('markings')} className={`px-3 py-1 rounded-lg text-xs font-bold ${activeSection==='markings' ? 'bg-emerald-600 text-white' : (isDarkMode ? 'bg-gray-700 text-gray-200' : 'bg-gray-100 text-gray-700')}`}>Nişanlanma xəttləri</button>
-          <button onClick={() => setActiveSection('vertical')} className={`px-3 py-1 rounded-lg text-xs font-bold ${activeSection==='vertical' ? 'bg-emerald-600 text-white' : (isDarkMode ? 'bg-gray-700 text-gray-200' : 'bg-gray-100 text-gray-700')}`}>Vertikal nişanlar</button>
-        </div>
-
-        {/* Content Area */}
-        {activeSection === 'signs' && (
-          <div>
-            {/* Sign categories */}
-            <div className="flex gap-2 overflow-x-auto pb-1 mb-2">
-              {SIGN_CATEGORIES.map(cat => (
-                <button
-                  key={cat.key}
-                  onClick={() => { setActiveSignCategory(cat.key); setSelectedSignId(null); }}
-                  className={`px-3 py-1 whitespace-nowrap rounded-lg text-xs font-medium border ${activeSignCategory===cat.key ? 'bg-emerald-600 text-white border-emerald-600' : (isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700')}`}
-                >
-                  {cat.title}
-                </button>
-              ))}
-            </div>
-
-            {/* Signs list */}
-            <div className="grid grid-cols-2 gap-2">
-              {filteredSigns.map((s, idx) => (
-                <SlideTransition key={s.id} direction="right" delay={200 + idx * 50}>
-                  <button
-                    onClick={() => setSelectedSignId(s.id)}
-                    className={`rounded-xl border shadow-sm p-3 flex items-center gap-3 transition-colors min-h-[48px] ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}
-                  >
-                    <div className={`w-12 h-12 rounded-lg flex items-center justify-center overflow-hidden ${isDarkMode ? 'bg-gray-700' : 'bg-gray-50'}`}>
-                      <img src={s.img} alt={s.name} className="w-10 h-10 object-contain" onError={handleImgError} />
-                    </div>
-                    <div className="text-left">
-                      <div className={`font-bold text-sm ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{s.name}</div>
-                      <div className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Baxmaq üçün toxunun</div>
-                    </div>
-                  </button>
-                </SlideTransition>
-              ))}
-            </div>
-
-            {/* Sign detail */}
-            {selectedSign && (
-              <Card className="mt-2">
-                <div className="flex items-center gap-3">
-                  <div className="w-16 h-16 rounded-lg overflow-hidden flex items-center justify-center bg-gray-50">
-                    <img src={selectedSign.img} alt={selectedSign.name} className="w-14 h-14 object-contain" onError={handleImgError} />
-                  </div>
-                  <div>
-                    <div className="font-bold text-sm">{selectedSign.name}</div>
-                    <div className="text-xs text-gray-600">{selectedSign.description}</div>
-                  </div>
+      {view === 'home' ? (
+        <Card className="mb-3">
+          <div className="grid grid-cols-1 gap-2">
+            <button onClick={() => setView('signs')} className={`w-full p-4 rounded-xl border flex items-center justify-between ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}>
+              <div className="flex items-center gap-3">
+                <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-lg ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}>🛑</div>
+                <div className="text-left">
+                  <div className="font-bold text-sm">Nişanlar</div>
+                  <div className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Qadağan, üstünlük, xəbərdarlıq və s.</div>
                 </div>
-              </Card>
-            )}
+              </div>
+              <span className={`${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>›</span>
+            </button>
+            <button onClick={() => setView('markings')} className={`w-full p-4 rounded-xl border flex items-center justify-between ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}>
+              <div className="flex items-center gap-3">
+                <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-lg ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}>〰️</div>
+                <div className="text-left">
+                  <div className="font-bold text-sm">Nişanlanma xəttləri</div>
+                  <div className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Yol üfüqi nişanlanmaları</div>
+                </div>
+              </div>
+              <span className={`${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>›</span>
+            </button>
+            <button onClick={() => setView('vertical')} className={`w-full p-4 rounded-xl border flex items-center justify-between ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}>
+              <div className="flex items-center gap-3">
+                <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-lg ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}>📶</div>
+                <div className="text-left">
+                  <div className="font-bold text-sm">Vertikal nişanlar</div>
+                  <div className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Dayaq sütunları, əks etdiricilər</div>
+                </div>
+              </div>
+              <span className={`${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>›</span>
+            </button>
           </div>
-        )}
-
-        {activeSection === 'markings' && (
-          <div>
-            <div className="grid grid-cols-2 gap-2">
-              {filteredMarkings.map(m => (
-                <Card key={m.id} className="p-3">
-                  <div className="font-bold text-sm">{m.name}</div>
-                  <div className="text-xs text-gray-600">{m.description}</div>
-                </Card>
-              ))}
+        </Card>
+      ) : (
+        <Card className="mb-3">
+          <div className="flex items-center justify-between mb-2">
+            <button onClick={() => setView('home')} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+            <div className={`text-xs uppercase tracking-wide font-bold ${isDarkMode ? 'text-gray-300' : 'text-gray-500'}`}>
+              {view === 'signs' && 'Nişanlar'}
+              {view === 'markings' && 'Nişanlanma xəttləri'}
+              {view === 'vertical' && 'Vertikal nişanlar'}
             </div>
+            <div className="opacity-0">←</div>
           </div>
-        )}
 
-        {activeSection === 'vertical' && (
-          <div>
-            <div className="grid grid-cols-2 gap-2">
-              {filteredVertical.map(v => (
-                <Card key={v.id} className="p-3">
-                  <div className="font-bold text-sm">{v.name}</div>
-                  <div className="text-xs text-gray-600">{v.description}</div>
+          {view === 'signs' && (
+            <div>
+              <div className="flex gap-2 overflow-x-auto pb-1 mb-2">
+                {SIGN_CATEGORIES.map(cat => (
+                  <button
+                    key={cat.key}
+                    onClick={() => { setActiveSignCategory(cat.key); setSelectedSignId(null); }}
+                    className={`px-3 py-1 whitespace-nowrap rounded-lg text-xs font-medium border ${activeSignCategory===cat.key ? 'bg-emerald-600 text-white border-emerald-600' : (isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700')}`}
+                  >
+                    {cat.title}
+                  </button>
+                ))}
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                {filteredSigns.map((s, idx) => (
+                  <SlideTransition key={s.id} direction="right" delay={200 + idx * 50}>
+                    <button
+                      onClick={() => setSelectedSignId(s.id)}
+                      className={`rounded-xl border shadow-sm p-3 flex items-center gap-3 transition-colors min-h-[48px] ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}
+                    >
+                      <div className={`w-12 h-12 rounded-lg flex items-center justify-center overflow-hidden ${isDarkMode ? 'bg-gray-700' : 'bg-gray-50'}`}>
+                        <img src={s.img} alt={s.name} className="w-10 h-10 object-contain" onError={handleImgError} />
+                      </div>
+                      <div className="text-left">
+                        <div className={`font-bold text-sm ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{s.name}</div>
+                        <div className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Baxmaq üçün toxunun</div>
+                      </div>
+                    </button>
+                  </SlideTransition>
+                ))}
+              </div>
+
+              {selectedSign && (
+                <Card className="mt-2">
+                  <div className="flex items-center gap-3">
+                    <div className="w-16 h-16 rounded-lg overflow-hidden flex items-center justify-center bg-gray-50">
+                      <img src={selectedSign.img} alt={selectedSign.name} className="w-14 h-14 object-contain" onError={handleImgError} />
+                    </div>
+                    <div>
+                      <div className="font-bold text-sm">{selectedSign.name}</div>
+                      <div className="text-xs text-gray-600">{selectedSign.description}</div>
+                    </div>
+                  </div>
                 </Card>
-              ))}
+              )}
             </div>
-          </div>
-        )}
-      </Card>
+          )}
+
+          {view === 'markings' && (
+            <div>
+              <div className="grid grid-cols-2 gap-2">
+                {filteredMarkings.map(m => (
+                  <Card key={m.id} className="p-3">
+                    <div className="font-bold text-sm">{m.name}</div>
+                    <div className="text-xs text-gray-600">{m.description}</div>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {view === 'vertical' && (
+            <div>
+              <div className="grid grid-cols-2 gap-2">
+                {filteredVertical.map(v => (
+                  <Card key={v.id} className="p-3">
+                    <div className="font-bold text-sm">{v.name}</div>
+                    <div className="text-xs text-gray-600">{v.description}</div>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          )}
+        </Card>
+      )}
 
       {/* Rules list always below the sections */}
       <Card>

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -75,7 +75,7 @@ const AZ_RULES = [
 ];
 
 export function RulesScreen() {
-  const { isDarkMode, goBack } = useApp();
+  const { isDarkMode, goBack, switchTab } = useApp();
   // Home with 3 entries; each opens its own sub-view
   const [view, setView] = useState<'home' | 'signs' | 'markings' | 'vertical'>('home');
   const [activeSignCategory, setActiveSignCategory] = useState<SignCategoryKey>('prohibitory');
@@ -115,18 +115,15 @@ export function RulesScreen() {
   };
 
   const handleBackClick = () => {
-    if (view === 'signs' && signsStage === 'detail') {
-      setSignsStage('categories');
-      setSelectedSignId(null);
-      return;
-    }
-    if (view !== 'home') {
-      setView('home');
-      return;
-    }
-    if (goBack) {
-      try { goBack(); } catch (_) { /* noop */ }
-    }
+    // Top bar back: always to app main Home tab
+    try {
+      if (switchTab) {
+        switchTab('Home');
+        return;
+      }
+    } catch (_) {}
+    // Fallback
+    try { goBack(); } catch (_) { /* noop */ }
   };
 
   return (
@@ -221,7 +218,7 @@ export function RulesScreen() {
               ) : (
                 <>
                   <div className="mb-2">
-                    <button onClick={() => { setSignsStage('categories'); setSelectedSignId(null); }} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+                    <button onClick={() => { setSignsStage('categories'); setSelectedSignId(null); }} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← 3 seçimə qayıt</button>
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     {filteredSigns.map((s, idx) => (

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -134,7 +134,7 @@ export function RulesScreen() {
       isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
     }`}>
       {/* Search / Filter */}
-      <div className={`mb-3 sticky top-0 z-30 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
+      <div className={`mb-3 sticky top-[44px] z-30 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
         <div className="flex items-center gap-2 py-1">
           <button onClick={handleBackClick} className={`px-3 py-2 rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700'}`}>←</button>
           <div className={`flex items-center gap-2 flex-1 px-3 py-2 rounded-xl border ${

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -134,7 +134,7 @@ export function RulesScreen() {
       isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
     }`}>
       {/* Search / Filter */}
-      <div className={`mb-3 sticky top-[44px] z-30 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
+      <div className={`mb-3 sticky top-0 z-40 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
         <div className="flex items-center gap-2 py-1">
           <button onClick={handleBackClick} className={`px-3 py-2 rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700'}`}>←</button>
           <div className={`flex items-center gap-2 flex-1 px-3 py-2 rounded-xl border ${

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -44,11 +44,20 @@ const VERTICAL_SIGNS = [
   { id: 'vs2', name: 'Maneə əks etdiricisi', description: 'Maneələrin kənarlarını göstərir.' },
 ];
 
-// Demo rules/articles
+// AZ traffic rules topics (titles + brief summaries)
 const AZ_RULES = [
-  { id: 'r1', title: '1. Ümumi müddəalar', content: 'Yol hərəkəti qaydalarının ümumi prinsipləri...' },
-  { id: 'r2', title: '2. Sürücünün vəzifələri', content: 'Sürücünün əsas vəzifələri və məsuliyyətləri...' },
-  { id: 'r3', title: '3. Piyadaların vəzifələri', content: 'Piyadaların hərəkət qaydaları...' },
+  { id: 'r1', title: 'Maddə 1. Əsas anlayışlar', content: 'Qanunda işlədilən termin və anlayışların izahı verilir. Nəqliyyat vasitəsi, sürücü, sərnişin, piyada, yol, yol hərəkəti iştirakçısı kimi anlayışlar dəqiq müəyyənləşdirilir. Bu anlayışlar bütün digər maddələrin düzgün başa düşülməsi üçün bazadır.' },
+  { id: 'r2', title: 'Maddə 2. Qanunun təyinatı', content: 'Qanunun məqsədi yol hərəkətində təhlükəsizliyi təmin etmək və hərəkətin təşkili üçün hüquqi çərçivə yaratmaqdır. Həm sürücülər, həm də digər iştirakçılar üçün ümumi davranış qaydaları müəyyən edilir.' },
+  { id: 'r3', title: 'Maddə 3. Yol hərəkəti haqqında qanunvericilik', content: 'Yol hərəkətini tənzimləyən normativ aktların sistemi göstərilir. Qanunun digər qaydalar və standartlarla əlaqəsi və üstünlük münasibətləri izah olunur.' },
+  { id: 'r4', title: 'Maddə 4. Dövlət orqanlarının vəzifələri', content: 'Yol hərəkəti sahəsində nəzarət, təşkil və təhlükəsizliyin təmin edilməsi üzrə dövlət qurumlarının səlahiyyətləri təsbit olunur. Təlim, maarifləndirmə və infrastrukturun saxlanması da bu vəzifələrə daxildir.' },
+  { id: 'r5', title: 'Maddə 5. Hüquqi şəxslərin vəzifələri', content: 'Daşıma fəaliyyəti göstərən və ya nəqliyyat parkı olan təşkilatların öhdəlikləri müəyyən edilir. Texniki sazlıq, sürücülərin hazırlığı və təhlükəsizlik tələblərinə əməl olunması şərtdir.' },
+  { id: 'r6', title: 'Maddə 6. Fiziki şəxslərin hüquq və vəzifələri', content: 'Sürücü və piyadaların hüquqları, vəzifələri və məsuliyyəti göstərilir. Hərəkət zamanı bir-birinə hörmət və təhlükəsizliyin təmin edilməsi əsas prinsipdir.' },
+  { id: 'r7', title: 'Maddə 6-1. Beynəlxalq daşımalarda iştirak edənlərin vəzifələri', content: 'Beynəlxalq sərnişin və yük daşımalarını təşkil edən və icra edən şəxslərə əlavə tələblər müəyyən olunur. Sənədləşmə, təhlükəsizlik və beynəlxalq normalara uyğunluq önəmlidir.' },
+  { id: 'r8', title: 'Maddə 7. Yol hərəkətinin təşkili', content: 'Yol hərəkatının planlaşdırılması, nişan və nişanlanmaların tətbiqi qaydaları izah edilir. Hərəkət axınının təhlükəsiz və fasiləsiz olması üçün təşkilati tədbirlər nəzərdə tutulur.' },
+  { id: 'r9', title: 'Maddə 8. Hərəkətə başlama və manevr', content: 'Hərəkətə başlama, dönmə, ötmə, zolaq dəyişmə və digər manevrlərin qaydaları təsvir olunur. Sürücü əvvəlcədən siqnal verməli və təhlükəsizliyi təmin etməlidir.' },
+  { id: 'r10', title: 'Maddə 9. Dayanma və durma', content: 'Dayanma və durmanın icazəli və qadağan edildiyi hallar göstərilir. Qaydaların pozulması yol hərəkətinə maneə yarada və təhlükə doğura bilər.' },
+  { id: 'r11', title: 'Maddə 10. Sürət rejimi', content: 'Müxtəlif yol şəraitlərində tətbiq olunan sürət məhdudiyyətləri müəyyən edilir. Zərurət yarandıqda sürət hava, yol və nəqliyyat axınına uyğun azaldılmalıdır.' },
+  { id: 'r12', title: 'Maddə 11. Piyadaların hərəkəti', content: 'Piyadaların keçidlərdən istifadə qaydaları, yolun təhlükəsiz keçilməsi və gecə-gündüz görünmə tələbləri izah olunur. Sürücülər piyadalara xüsusi diqqət yetirməlidirlər.' },
 ];
 
 export function RulesScreen() {
@@ -59,6 +68,8 @@ export function RulesScreen() {
   const [selectedSignId, setSelectedSignId] = useState<string | null>(null);
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const [signsStage, setSignsStage] = useState<'categories' | 'detail'>('categories');
+  const [selectedCategory, setSelectedCategory] = useState<SignCategoryKey | null>(null);
 
   const currentSigns = useMemo(() => SIGNS[activeSignCategory] || [], [activeSignCategory]);
   const selectedSign = useMemo(() => currentSigns.find(s => s.id === selectedSignId) || null, [currentSigns, selectedSignId]);
@@ -118,7 +129,7 @@ export function RulesScreen() {
       {view === 'home' ? (
         <Card className="mb-3">
           <div className="grid grid-cols-1 gap-2">
-            <button onClick={() => setView('signs')} className={`w-full p-4 rounded-xl border flex items-center justify-between ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}>
+            <button onClick={() => { setView('signs'); setSignsStage('categories'); setSelectedCategory(null); }} className={`w-full p-4 rounded-xl border flex items-center justify-between ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}>
               <div className="flex items-center gap-3">
                 <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-lg ${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}`}>🛑</div>
                 <div className="text-left">
@@ -153,9 +164,9 @@ export function RulesScreen() {
       ) : (
         <Card className="mb-3">
           <div className="flex items-center justify-between mb-2">
-            <button onClick={() => setView('home')} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
+            <button onClick={() => { if (view === 'signs' && signsStage === 'detail') { setSignsStage('categories'); setSelectedSignId(null); } else { setView('home'); } }} className={`px-2 py-1 rounded-lg text-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-100 text-gray-700'}`}>← Geri</button>
             <div className={`text-xs uppercase tracking-wide font-bold ${isDarkMode ? 'text-gray-300' : 'text-gray-500'}`}>
-              {view === 'signs' && 'Nişanlar'}
+              {view === 'signs' && (signsStage === 'categories' ? 'Nişanlar' : (SIGN_CATEGORIES.find(c => c.key === selectedCategory)?.title || 'Nişanlar'))}
               {view === 'markings' && 'Nişanlanma xəttləri'}
               {view === 'vertical' && 'Vertikal nişanlar'}
             </div>
@@ -164,49 +175,54 @@ export function RulesScreen() {
 
           {view === 'signs' && (
             <div>
-              <div className="flex gap-2 overflow-x-auto pb-1 mb-2">
-                {SIGN_CATEGORIES.map(cat => (
-                  <button
-                    key={cat.key}
-                    onClick={() => { setActiveSignCategory(cat.key); setSelectedSignId(null); }}
-                    className={`px-3 py-1 whitespace-nowrap rounded-lg text-xs font-medium border ${activeSignCategory===cat.key ? 'bg-emerald-600 text-white border-emerald-600' : (isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700')}`}
-                  >
-                    {cat.title}
-                  </button>
-                ))}
-              </div>
-
-              <div className="grid grid-cols-2 gap-2">
-                {filteredSigns.map((s, idx) => (
-                  <SlideTransition key={s.id} direction="right" delay={200 + idx * 50}>
+              {signsStage === 'categories' ? (
+                <div className="space-y-2">
+                  {SIGN_CATEGORIES.map(cat => (
                     <button
-                      onClick={() => setSelectedSignId(s.id)}
-                      className={`rounded-xl border shadow-sm p-3 flex items-center gap-3 transition-colors min-h-[48px] ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}
+                      key={cat.key}
+                      onClick={() => { setSelectedCategory(cat.key); setActiveSignCategory(cat.key); setSelectedSignId(null); setSignsStage('detail'); }}
+                      className={`w-full p-3 flex items-center justify-between rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}
                     >
-                      <div className={`w-12 h-12 rounded-lg flex items-center justify-center overflow-hidden ${isDarkMode ? 'bg-gray-700' : 'bg-gray-50'}`}>
-                        <img src={s.img} alt={s.name} className="w-10 h-10 object-contain" onError={handleImgError} />
-                      </div>
-                      <div className="text-left">
-                        <div className={`font-bold text-sm ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{s.name}</div>
-                        <div className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Baxmaq üçün toxunun</div>
-                      </div>
+                      <div className="text-sm font-medium">{cat.title}</div>
+                      <span className={`${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>›</span>
                     </button>
-                  </SlideTransition>
-                ))}
-              </div>
-
-              {selectedSign && (
-                <Card className="mt-2">
-                  <div className="flex items-center gap-3">
-                    <div className="w-16 h-16 rounded-lg overflow-hidden flex items-center justify-center bg-gray-50">
-                      <img src={selectedSign.img} alt={selectedSign.name} className="w-14 h-14 object-contain" onError={handleImgError} />
-                    </div>
-                    <div>
-                      <div className="font-bold text-sm">{selectedSign.name}</div>
-                      <div className="text-xs text-gray-600">{selectedSign.description}</div>
-                    </div>
+                  ))}
+                </div>
+              ) : (
+                <>
+                  <div className="grid grid-cols-2 gap-2">
+                    {filteredSigns.map((s, idx) => (
+                      <SlideTransition key={s.id} direction="right" delay={200 + idx * 50}>
+                        <button
+                          onClick={() => setSelectedSignId(s.id)}
+                          className={`rounded-xl border shadow-sm p-3 flex items-center gap-3 transition-colors min-h-[48px] ${isDarkMode ? 'bg-gray-800 border-gray-700 hover:bg-gray-700 text-gray-100' : 'bg-white border-gray-200 hover:bg-gray-50 text-gray-900'}`}
+                        >
+                          <div className={`w-12 h-12 rounded-lg flex items-center justify-center overflow-hidden ${isDarkMode ? 'bg-gray-700' : 'bg-gray-50'}`}>
+                            <img src={s.img} alt={s.name} className="w-10 h-10 object-contain" onError={handleImgError} />
+                          </div>
+                          <div className="text-left">
+                            <div className={`font-bold text-sm ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{s.name}</div>
+                            <div className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>Baxmaq üçün toxunun</div>
+                          </div>
+                        </button>
+                      </SlideTransition>
+                    ))}
                   </div>
-                </Card>
+
+                  {selectedSign && (
+                    <Card className="mt-2">
+                      <div className="flex items-center gap-3">
+                        <div className="w-16 h-16 rounded-lg overflow-hidden flex items-center justify-center bg-gray-50">
+                          <img src={selectedSign.img} alt={selectedSign.name} className="w-14 h-14 object-contain" onError={handleImgError} />
+                        </div>
+                        <div>
+                          <div className="font-bold text-sm">{selectedSign.name}</div>
+                          <div className="text-xs text-gray-600">{selectedSign.description}</div>
+                        </div>
+                      </div>
+                    </Card>
+                  )}
+                </>
               )}
             </div>
           )}


### PR DESCRIPTION
Add a new 'Qaydalar' (Rules) screen with a search bar, categorized traffic signs, and an expandable list of Azerbaijani traffic rules, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c3ad846-142b-42cc-8e9e-ae2039f44f1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c3ad846-142b-42cc-8e9e-ae2039f44f1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

