### PR TITLE
Display question video explanations on incorrect answers

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -108,6 +108,7 @@ export const SAMPLE_QUESTIONS: Question[] = [
     moduleId: 'M1',
     text: 'C avtomobilinin sürücüsü bu şəraitdə hansı nəqliyyat vasitələrinə yol verməlidir?',
     imageUrl: 'https://images.pexels.com/photos/163064/play-stone-network-networked-interactive-163064.jpeg?auto=compress&cs=tinysrgb&w=800',
+    videoUrl: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
     options: [
       { id: 'o1', text: 'Yalnız 1 №-li tramvaya.' },
       { id: 'o2', text: 'Yalnız 2 №-li tramvaya.' },
@@ -121,6 +122,7 @@ export const SAMPLE_QUESTIONS: Question[] = [
     id: 'q2',
     moduleId: 'M1',
     text: 'Şəkildə neçə yolayrıcı göstərilmişdir?',
+    videoUrl: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
     options: [
       { id: 'o1', text: '1' },
       { id: 'o2', text: '2' },
@@ -134,6 +136,7 @@ export const SAMPLE_QUESTIONS: Question[] = [
     id: 'q3',
     moduleId: 'M1',
     text: 'Bu şəraitdə hansı avtomobil tramvaya nisbətən üstünlüyə malikdir?',
+    videoUrl: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
     options: [
       { id: 'o1', text: 'A avtomobili' },
       { id: 'o2', text: 'B avtomobili' },
@@ -147,6 +150,7 @@ export const SAMPLE_QUESTIONS: Question[] = [
     id: 'q4',
     moduleId: 'M1',
     text: 'Bu şəraitdə hansı avtomobilin sürücüsü digər avtomobillərə yol vermədən hərəkəti davam etdirə bilər?',
+    videoUrl: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
     options: [
       { id: 'o1', text: 'Solda yerləşən avtomobil' },
       { id: 'o2', text: 'Sağda yerləşən avtomobil' },

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -48,6 +48,9 @@ export const dictionaries = {
     timeLeft: 'Qalan vaxt',
     confirmAnswer: 'Cavabı təsdiq et',
     explanation: 'İzah',
+    explanationImage: 'Şəkil',
+    explanationVideo: 'Video',
+    close: 'Bağla',
     
     // Results
     yourScore: 'Sənin balın',
@@ -121,6 +124,9 @@ export const dictionaries = {
     timeLeft: 'Осталось',
     confirmAnswer: 'Подтвердить ответ',
     explanation: 'Пояснение',
+    explanationImage: 'Изображение',
+    explanationVideo: 'Видео',
+    close: 'Закрыть',
     
     // Results
     yourScore: 'Твой балл',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,4 +1,4 @@
-import type { Language } from './types';
+// i18n dictionary definitions
 
 export const dictionaries = {
   az: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,7 @@ export interface Question {
   moduleId: string;
   text: string;
   imageUrl?: string;
+  videoUrl?: string;
   options: QuestionOption[];
   correctOptionId: string;
   explanation: string;

--- a/src/types/react-jsx-runtime.d.ts
+++ b/src/types/react-jsx-runtime.d.ts
@@ -1,0 +1,7 @@
+declare module 'react/jsx-runtime' {
+  export const jsx: any;
+  export const jsxs: any;
+  export const Fragment: any;
+  const _default: any;
+  export default _default;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["react", "react-dom"],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Implement a video/image explanation overlay for Quick Test questions, triggered by wrong answers or the 'İzah' button, to provide comprehensive explanations.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c8af17d-6339-427c-9ec7-8721c8b19317">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c8af17d-6339-427c-9ec7-8721c8b19317">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

