### PR TITLE
Adjust tab bar visibility and back navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,13 @@ function AppContent() {
 
   const isAIChat = currentScreen.screen === 'AIChat';
   const hideHeader = currentScreen.screen !== 'Home';
-  const hideTabBar = currentScreen.screen === 'ExamRun' || currentScreen.screen === 'ProductDetail' || currentScreen.screen === 'Cart';
+  const hideTabBar =
+    currentScreen.screen === 'ExamRun' ||
+    currentScreen.screen === 'ProductDetail' ||
+    currentScreen.screen === 'Cart' ||
+    currentScreen.screen === 'Store' ||
+    currentScreen.screen === 'Rules' ||
+    currentScreen.screen === 'Fines';
 
   return (
     <div className={`min-h-screen transition-colors duration-200 ${

--- a/src/components/screens/AIChatScreen.tsx
+++ b/src/components/screens/AIChatScreen.tsx
@@ -189,9 +189,10 @@ export function AIChatScreen() {
             <div className="flex items-center gap-3">
               <button
                 onClick={goBack}
+                aria-label="Geri"
                 className="w-9 h-9 rounded-lg border border-gray-300 bg-gray-50 flex items-center justify-center hover:bg-gray-100"
               >
-                ←
+                <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
               </button>
               <button
                 onClick={() => setHistoryOpen(!historyOpen)}

--- a/src/components/screens/FinesScreen.tsx
+++ b/src/components/screens/FinesScreen.tsx
@@ -72,7 +72,9 @@ export function FinesScreen() {
       {/* Search / Header */}
       <div className={`mb-3 sticky top-0 z-40 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
         <div className="flex items-center gap-2 py-1">
-          <button onClick={handleBackClick} className={`px-3 py-2 rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700'}`}>←</button>
+          <button onClick={handleBackClick} aria-label="Geri" className={`h-9 w-9 rounded-full flex items-center justify-center border shadow-sm transition-all duration-200 ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700' : 'bg-white border-gray-200 text-gray-900 hover:bg-gray-100'}`}>
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
+          </button>
           <div className={`flex items-center gap-2 flex-1 px-3 py-2 rounded-xl border ${
             isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
           }`}>

--- a/src/components/screens/OnlineLessonsScreen.tsx
+++ b/src/components/screens/OnlineLessonsScreen.tsx
@@ -85,9 +85,10 @@ export function OnlineLessonsScreen() {
       <div className="-mx-3 -mt-2 mb-3 px-3 py-3 flex items-center gap-3">
         <button
           onClick={goBack}
-          className={`px-3 py-1.5 rounded-lg text-xs font-semibold shadow-sm ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-white text-gray-700 border border-gray-200'}`}
+          aria-label="Geri"
+          className={`h-9 w-9 rounded-full flex items-center justify-center border shadow-sm ${isDarkMode ? 'bg-gray-800 text-gray-200 border-gray-700 hover:bg-gray-700' : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-100'}`}
         >
-          ← {t.home}
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
         </button>
         <div className={`text-lg font-extrabold tracking-tight ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{t.onlineLesson}</div>
       </div>

--- a/src/components/screens/PackagesScreen.tsx
+++ b/src/components/screens/PackagesScreen.tsx
@@ -239,13 +239,14 @@ export function PackagesScreen() {
       <div className="flex items-center gap-3 mb-4">
         <button
           onClick={goBack}
+          aria-label="Geri"
           className={`w-9 h-9 rounded-lg border flex items-center justify-center transition-colors duration-200 ${
             isDarkMode 
               ? 'border-gray-600 bg-gray-700 hover:bg-gray-600 text-gray-200' 
               : 'border-gray-300 bg-gray-50 hover:bg-gray-100 text-gray-700'
           }`}
         >
-          ←
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
         </button>
         <h1 className={`text-lg font-bold transition-colors duration-200 ${
           isDarkMode ? 'text-gray-100' : 'text-gray-900'

--- a/src/components/screens/RulesScreen.tsx
+++ b/src/components/screens/RulesScreen.tsx
@@ -107,7 +107,9 @@ export function RulesScreen() {
       {/* Search / Filter */}
       <div className={`mb-3 sticky top-0 z-40 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
         <div className="flex items-center gap-2 py-1">
-          <button onClick={handleBackClick} className={`px-3 py-2 rounded-xl border ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-200' : 'bg-white border-gray-200 text-gray-700'}`}>←</button>
+          <button onClick={handleBackClick} aria-label="Geri" className={`h-9 w-9 rounded-full flex items-center justify-center border shadow-sm transition-all duration-200 ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700' : 'bg-white border-gray-200 text-gray-900 hover:bg-gray-100'}`}>
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
+          </button>
           <div className={`flex items-center gap-2 flex-1 px-3 py-2 rounded-xl border ${
             isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
           }`}>

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -56,13 +56,14 @@ export function SettingsScreen() {
         <div className="flex items-center gap-3 mb-6">
           <button
             onClick={goBack}
+            aria-label="Geri"
             className={`w-9 h-9 rounded-lg border flex items-center justify-center transition-colors duration-200 ${
               isDarkMode 
                 ? 'border-gray-600 bg-gray-700 hover:bg-gray-600 text-gray-200' 
                 : 'border-gray-300 bg-gray-50 hover:bg-gray-100 text-gray-700'
             }`}
           >
-            ←
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
           </button>
           <h1 className={`text-lg font-bold transition-colors duration-200 ${
             isDarkMode ? 'text-gray-100' : 'text-gray-900'

--- a/src/components/screens/StoreScreen.tsx
+++ b/src/components/screens/StoreScreen.tsx
@@ -6,7 +6,7 @@ import { ProductCard } from '../ui/ProductCard';
 import { STORE_PRODUCTS } from '../../lib/products';
 
 export function StoreScreen() {
-  const { isDarkMode, navigate, addToCart } = useApp();
+  const { isDarkMode, navigate, addToCart, switchTab } = useApp();
   const cartBtnRef = React.useRef<HTMLButtonElement | null>(null);
   const [q, setQ] = React.useState('');
   const [minPrice, setMinPrice] = React.useState('');
@@ -80,10 +80,22 @@ export function StoreScreen() {
     <div className={`p-3 pb-24 min-h-screen transition-colors duration-200 ${
       isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
     }`}>
-      <div className="mb-3 text-center">
-        <h1 className={`text-2xl font-bold mb-2 transition-colors duration-200 ${
-          isDarkMode ? 'text-gray-100' : 'text-gray-900'
-        }`}>Onlayn mağaza</h1>
+      <div className="mb-3">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => switchTab('Home')}
+            className={`h-9 w-9 rounded-full flex items-center justify-center border shadow-sm transition-all duration-200 ${isDarkMode ? 'bg-gray-800 border-gray-700 text-gray-100 hover:bg-gray-700' : 'bg-white border-gray-200 text-gray-900 hover:bg-gray-100'}`}
+            aria-label="Geri"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+          </button>
+          <h1 className={`text-2xl font-bold transition-colors duration-200 ${
+            isDarkMode ? 'text-gray-100' : 'text-gray-900'
+          }`}>Onlayn mağaza</h1>
+        </div>
+        
         <div className="mt-1 rounded-md px-3 py-1 inline-block text-xs font-semibold text-white bg-red-600 whitespace-nowrap">
           20 manatdan yuxarı çatdırılma pulsuzdur
         </div>

--- a/src/components/screens/TeacherContactScreen.tsx
+++ b/src/components/screens/TeacherContactScreen.tsx
@@ -58,9 +58,10 @@ export function TeacherContactScreen() {
       <div className="flex items-center gap-3 mb-4">
         <button
           onClick={goBack}
+          aria-label="Geri"
           className="w-9 h-9 rounded-lg border border-gray-300 bg-gray-50 flex items-center justify-center hover:bg-gray-100"
         >
-          ←
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
         </button>
         <h1 className="text-lg font-bold text-gray-900">Sualını qeyd et</h1>
       </div>

--- a/src/components/screens/TransactionsScreen.tsx
+++ b/src/components/screens/TransactionsScreen.tsx
@@ -13,13 +13,14 @@ export function TransactionsScreen() {
       <div className="flex items-center gap-3 mb-4">
         <button
           onClick={goBack}
+          aria-label="Geri"
           className={`w-9 h-9 rounded-lg border flex items-center justify-center transition-colors duration-200 ${
             isDarkMode 
               ? 'border-gray-600 bg-gray-700 hover:bg-gray-600 text-gray-200' 
               : 'border-gray-300 bg-gray-50 hover:bg-gray-100 text-gray-700'
           }`}
         >
-          ←
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
         </button>
         <h1 className={`text-lg font-bold transition-colors duration-200 ${
           isDarkMode ? 'text-gray-100' : 'text-gray-900'


### PR DESCRIPTION
Hide TabBar on Fines, Rules, and Store pages, add a back button to the Online Store, and center back arrow icons across relevant screens.

This improves navigation consistency and user experience by ensuring the TabBar is not visible on specific content pages, providing a clear way to return from the store, and standardizing the appearance of back buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-85756851-0542-4203-952b-b6c8443a04c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85756851-0542-4203-952b-b6c8443a04c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

