### PR TITLE
Təlim paketləri səhifəsini yenidən tərtib et

### DIFF
--- a/src/components/screens/PackagesScreen.tsx
+++ b/src/components/screens/PackagesScreen.tsx
@@ -336,7 +336,7 @@ export function PackagesScreen() {
         </div>
 
         {activeTab === 'training' && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4">
             {packages.map((pkg, index) => (
               <div key={pkg.id} className="relative group">
                 {/* Modern Package Card - Enhanced for Basic Package */}


### PR DESCRIPTION
Display training packages in a single column by removing `md:grid-cols-2` to ensure they are shown separately instead of side-by-side.

---
<a href="https://cursor.com/background-agent?bcId=bc-51930794-cf7b-4ba9-810e-7532fd1d778e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51930794-cf7b-4ba9-810e-7532fd1d778e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

